### PR TITLE
feat: CLI UX framework — Spark mascot, progress indicators, vibrant o…

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,13 +7,21 @@ import { createLogsCommand } from "../commands/logs.js";
 import { createAdaptorCommand } from "../commands/adaptor.js";
 import { createChatCommand } from "../commands/chat.js";
 import { createDataCommand } from "../commands/data.js";
+import { initUiContext } from "../ui/index.js";
 
 const program = new Command();
 
 program
   .name("coder")
   .description("Local AI code generation CLI")
-  .version("0.1.0");
+  .version("0.1.0")
+  .option("-q, --quiet", "Suppress all progress output (for scripting)");
+
+// Initialise UiContext before any subcommand action runs.
+program.hook("preAction", (root) => {
+  const opts = root.opts<{ quiet?: boolean }>();
+  initUiContext({ quiet: opts.quiet === true });
+});
 
 program.addCommand(createGenerateCommand());
 program.addCommand(createConfigCommand());

--- a/src/commands/adaptor.ts
+++ b/src/commands/adaptor.ts
@@ -14,6 +14,7 @@ import { runSelfImprove } from "../adaptors/self-improve.js";
 import { logger } from "../observability/logger.js";
 import { join } from "node:path";
 import { existsSync, writeFileSync } from "node:fs";
+import { ui, renderTable, StepProgress, Spinner } from "../ui/index.js";
 
 function getAdaptorsDir(): string {
   return loadConfig().adaptors_dir;
@@ -29,17 +30,17 @@ export function createAdaptorCommand(): Command {
       const adaptorsDir = getAdaptorsDir();
       const entries = listAdaptors(adaptorsDir);
 
-      const header = `${"NAME".padEnd(20)} ${"VERSION".padEnd(10)} ${"DOMAIN".padEnd(15)} BASE_MODEL`;
-      process.stdout.write(header + "\n");
+      const rows = entries.map((e) => [
+        e.name,
+        e.manifest.version,
+        e.manifest.domain,
+        e.manifest.base_model,
+      ]);
 
-      for (const entry of entries) {
-        const line =
-          `${entry.name.padEnd(20)} ` +
-          `${entry.manifest.version.padEnd(10)} ` +
-          `${entry.manifest.domain.padEnd(15)} ` +
-          `${entry.manifest.base_model}\n`;
-        process.stdout.write(line);
-      }
+      process.stdout.write(renderTable(
+        ["NAME", "VERSION", "DOMAIN", "BASE_MODEL"],
+        rows,
+      ));
     });
 
   cmd
@@ -49,12 +50,11 @@ export function createAdaptorCommand(): Command {
     .action(async (name: string, options: { fromGit: string }) => {
       const adaptorsDir = getAdaptorsDir();
       try {
+        const spinner = new Spinner(`Installing ${name}`).start();
         await installAdaptor(name, options.fromGit, adaptorsDir);
-        process.stdout.write(`Installed ${name}\n`);
+        spinner.succeed(`Installed ${name}`);
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
     });
@@ -65,12 +65,11 @@ export function createAdaptorCommand(): Command {
     .action(async (name: string) => {
       const adaptorsDir = getAdaptorsDir();
       try {
+        const spinner = new Spinner(`Updating ${name}`).start();
         await updateAdaptor(name, adaptorsDir);
-        process.stdout.write(`Updated ${name}\n`);
+        spinner.succeed(`Updated ${name}`);
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
     });
@@ -83,7 +82,7 @@ export function createAdaptorCommand(): Command {
       const adaptorDir = join(adaptorsDir, name);
 
       if (!existsSync(adaptorDir)) {
-        process.stderr.write(`Error: adaptor "${name}" not found\n`);
+        ui.error(`adaptor "${name}" not found`);
         process.exit(1);
       }
 
@@ -111,9 +110,7 @@ export function createAdaptorCommand(): Command {
           );
         }
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
     });
@@ -125,11 +122,9 @@ export function createAdaptorCommand(): Command {
       const adaptorsDir = getAdaptorsDir();
       try {
         removeAdaptor(name, adaptorsDir);
-        process.stdout.write(`Removed ${name}\n`);
+        ui.success(`Removed ${name}`);
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
     });
@@ -142,12 +137,11 @@ export function createAdaptorCommand(): Command {
       const dryRun = process.env.CODER_DRY_RUN === "1";
       try {
         const config = loadTrainConfig(options.config);
+        // Training output (loss lines + sparkline) written directly to stderr inside runMlxTrain
         await runMlxTrain(config, dryRun);
-        process.stdout.write("Training complete.\n");
+        ui.success("Training complete.");
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
     });
@@ -170,9 +164,7 @@ export function createAdaptorCommand(): Command {
         const modelPath = options.model ?? config.default_model;
 
         if (!modelPath && !dryRun) {
-          process.stderr.write(
-            "Error: no model specified. Use --model or set default_model in config\n",
-          );
+          ui.error("no model specified. Use --model or set default_model in config");
           process.exit(1);
         }
 
@@ -180,12 +172,14 @@ export function createAdaptorCommand(): Command {
         const adaptorDir = join(adaptorsDir, name);
 
         if (!existsSync(adaptorDir)) {
-          process.stderr.write(`Error: adaptor "${name}" not found\n`);
+          ui.error(`adaptor "${name}" not found`);
           process.exit(1);
         }
 
         const weightsPath = join(adaptorDir, "weights");
         const adaptorPath = options.baseline === true ? undefined : weightsPath;
+
+        const progress = new StepProgress("Evaluating prompt");
 
         try {
           const summary = await runEval(adaptorDir, {
@@ -193,7 +187,12 @@ export function createAdaptorCommand(): Command {
             adaptorPath,
             inputFile: options.input,
             dryRun,
+            onProgress: (current, total, prompt) => {
+              progress.tick(current, total, prompt.slice(0, 40));
+            },
           });
+
+          progress.done(`${String(summary.records.length)} prompts evaluated`);
 
           process.stdout.write(formatEvalTable(summary) + "\n");
 
@@ -203,7 +202,7 @@ export function createAdaptorCommand(): Command {
 
           if (options.report) {
             writeFileSync(options.report, formatEvalReport(summary));
-            process.stdout.write(`Report written to ${options.report}\n`);
+            ui.success(`Report written to ${options.report}`);
           }
 
           const manifestPath = join(adaptorDir, "manifest.json");
@@ -211,9 +210,7 @@ export function createAdaptorCommand(): Command {
 
           const scoreField =
             options.baseline === true ? "baseline_pass_rate" : "eval_pass_rate";
-          process.stdout.write(
-            `Updated ${scoreField}: ${summary.meanComposite.toFixed(3)}\n`,
-          );
+          ui.success(`Updated ${scoreField}: ${summary.meanComposite.toFixed(3)}`);
 
           logger.logEvent({
             event: "eval_complete",
@@ -226,9 +223,7 @@ export function createAdaptorCommand(): Command {
             record_count: summary.records.length,
           });
         } catch (err) {
-          process.stderr.write(
-            `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-          );
+          ui.error(err instanceof Error ? err.message : String(err));
           process.exit(1);
         }
       },
@@ -261,9 +256,7 @@ export function createAdaptorCommand(): Command {
         const modelPath = options.model ?? config.default_model;
 
         if (!modelPath && !dryRun) {
-          process.stderr.write(
-            "Error: no model specified. Use --model or set default_model in config\n",
-          );
+          ui.error("no model specified. Use --model or set default_model in config");
           process.exit(1);
         }
 
@@ -271,7 +264,7 @@ export function createAdaptorCommand(): Command {
         const adaptorDir = join(adaptorsDir, name);
 
         if (!existsSync(adaptorDir)) {
-          process.stderr.write(`Error: adaptor "${name}" not found\n`);
+          ui.error(`adaptor "${name}" not found`);
           process.exit(1);
         }
 
@@ -281,10 +274,11 @@ export function createAdaptorCommand(): Command {
             : parseFloat(options.temperature);
 
         try {
+          const totalRounds = parseInt(options.rounds, 10);
           const results = await runSelfImprove({
             adaptorDir,
             modelPath,
-            rounds: parseInt(options.rounds, 10),
+            rounds: totalRounds,
             samplesPerPrompt: parseInt(options.samples, 10),
             threshold: parseFloat(options.threshold),
             temperature,
@@ -293,13 +287,15 @@ export function createAdaptorCommand(): Command {
 
           for (const r of results) {
             const delta = r.scoreAfter - r.scoreBefore;
-            const sign = delta >= 0 ? "+" : "";
-            const tag = r.committed ? "[committed]" : "[rolled back]";
+            const tag = r.committed
+              ? ui.scoreDelta(delta) + "  [committed]"
+              : ui.scoreDelta(delta) + "  [rolled back]";
+            ui.divider(`Round ${String(r.round)} / ${String(results.length)}`);
             process.stderr.write(
-              `Round ${String(r.round)}/${String(results.length)}: ` +
-              `generated ${String(r.generated)}  filtered (≥${options.threshold}): ${String(r.filtered)}  ` +
+              `  generated ${String(r.generated)}  ` +
+              `filtered (≥${options.threshold}): ${String(r.filtered)}  ` +
               `eval: ${r.scoreBefore.toFixed(3)} → ${r.scoreAfter.toFixed(3)} ` +
-              `(${sign}${delta.toFixed(3)})  ${tag}\n`,
+              `(${tag})\n`,
             );
           }
 
@@ -308,14 +304,13 @@ export function createAdaptorCommand(): Command {
             (score, r) => (r.committed ? r.scoreAfter : score),
             results[0]?.scoreBefore ?? 0,
           );
-          process.stdout.write(
-            `Self-improvement complete. Final score: ${finalScore.toFixed(3)} ` +
-            `(rounds committed: ${String(committed)}/${String(results.length)})\n`,
+          ui.divider();
+          ui.success(
+            `Self-improvement complete.  Final score: ${finalScore.toFixed(3)}  ` +
+            `(rounds committed: ${String(committed)}/${String(totalRounds)})`,
           );
         } catch (err) {
-          process.stderr.write(
-            `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-          );
+          ui.error(err instanceof Error ? err.message : String(err));
           process.exit(1);
         }
       },

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -8,6 +8,7 @@ import { logger } from "../observability/logger.js";
 import { formatPrompt, applyWindow } from "../chat/history.js";
 import type { Turn } from "../chat/history.js";
 import { capturePrompt } from "../adaptors/prompt-log.js";
+import { ui, MascotSpinner } from "../ui/index.js";
 
 export function createChatCommand(): Command {
   return new Command("chat")
@@ -20,9 +21,7 @@ export function createChatCommand(): Command {
         const model = options.model ?? (config.default_model || undefined);
 
         if (!model) {
-          process.stderr.write(
-            "Error: no model specified. Use --model <path> or set default_model in config.\n",
-          );
+          ui.error("no model specified. Use --model <path> or set default_model in config.");
           process.exit(1);
         }
 
@@ -109,22 +108,32 @@ export function createChatCommand(): Command {
             rawPrompt: true,
           });
 
+          // Show Spark mascot while waiting for the first token
+          const mascot = new MascotSpinner("Thinking").start();
+
           const reader = stream.getReader();
           cancelCurrentStream = () => { reader.cancel().catch(() => undefined); };
           let assistantResponse = "";
+          let firstToken = true;
 
           try {
             for (;;) {
               const { done, value } = await reader.read();
               if (done) break;
+              if (firstToken) {
+                mascot.stop();
+                firstToken = false;
+              }
               // Strip chat end tokens before printing
               const chunk = value.replace(/<\|im_end\|>/g, "").replace(/!\[\]<\|im_end\|>/g, "");
               process.stdout.write(chunk);
               assistantResponse += chunk;
             }
+            if (firstToken) mascot.stop(); // empty response
             process.stdout.write("\n");
           } catch {
             // Cancelled via SIGINT
+            mascot.stop();
             cancelCurrentStream = null;
             rl.prompt();
             continue;

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -11,6 +11,7 @@ import { computeStats } from "../data/stats.js";
 import { ExtractConfigSchema } from "../data/types.js";
 import type { JsonlRecord } from "../data/types.js";
 import { createDataPromptsCommand } from "./data-prompts.js";
+import { ui } from "../ui/index.js";
 
 function writeJsonl(records: JsonlRecord[], outPath: string): void {
   const dir = dirname(outPath);
@@ -38,9 +39,7 @@ export function createDataCommand(): Command {
       const jsonl = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
       if (options.output) {
         writeJsonl(records, options.output);
-        process.stderr.write(
-          `Ingested ${String(records.length)} records → ${options.output}\n`,
-        );
+        ui.success(`Ingested ${String(records.length)} records → ${options.output}`);
       } else {
         process.stdout.write(jsonl);
       }
@@ -62,9 +61,7 @@ export function createDataCommand(): Command {
         const raw = JSON.parse(readFileSync(extractJsonPath, "utf-8")) as unknown;
         extractConfig = ExtractConfigSchema.parse(raw);
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
 
@@ -99,9 +96,7 @@ export function createDataCommand(): Command {
 
       if (options.output) {
         writeJsonl(records, options.output);
-        process.stderr.write(
-          `Extracted ${String(records.length)} records → ${options.output}\n`,
-        );
+        ui.success(`Extracted ${String(records.length)} records → ${options.output}`);
       } else {
         process.stdout.write(records.map((r) => JSON.stringify(r)).join("\n") + "\n");
       }
@@ -116,9 +111,7 @@ export function createDataCommand(): Command {
       try {
         records = readJsonl(file);
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
 
@@ -130,9 +123,7 @@ export function createDataCommand(): Command {
       } else {
         process.stdout.write(jsonl);
       }
-      process.stderr.write(
-        `Removed ${String(removed)} duplicate(s). ${String(deduped.length)} records remain.\n`,
-      );
+      ui.success(`Removed ${String(removed)} duplicate(s). ${String(deduped.length)} records remain.`);
     });
 
   cmd
@@ -159,9 +150,7 @@ export function createDataCommand(): Command {
           (r) => (r.prompt.length + r.completion.length) / 4 < minTok,
         );
         if (short.length > 0) {
-          process.stderr.write(
-            `Warning: ${String(short.length)} record(s) below ${String(minTok)} token threshold\n`,
-          );
+          ui.warn(`${String(short.length)} record(s) below ${String(minTok)} token threshold`);
         }
       }
       if (summary.invalid > 0) {
@@ -185,9 +174,7 @@ export function createDataCommand(): Command {
         try {
           records = readJsonl(file);
         } catch (err) {
-          process.stderr.write(
-            `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-          );
+          ui.error(err instanceof Error ? err.message : String(err));
           process.exit(1);
         }
 
@@ -199,9 +186,7 @@ export function createDataCommand(): Command {
           );
           const dropped = before - records.length;
           if (dropped > 0) {
-            process.stderr.write(
-              `Dropped ${String(dropped)} record(s) below ${String(options.minTokens)} token threshold\n`,
-            );
+            ui.warn(`Dropped ${String(dropped)} record(s) below ${String(options.minTokens)} token threshold`);
           }
         }
 
@@ -224,8 +209,8 @@ export function createDataCommand(): Command {
         writeJsonl(train, trainPath);
         writeJsonl(evalSet, validPath);
 
-        process.stderr.write(`Train: ${String(train.length)} records → ${trainPath}\n`);
-        process.stderr.write(`Eval:  ${String(evalSet.length)} records → ${validPath}\n`);
+        ui.success(`Train: ${String(train.length)} records → ${trainPath}`);
+        ui.success(`Eval:  ${String(evalSet.length)} records → ${validPath}`);
       },
     );
 
@@ -237,9 +222,7 @@ export function createDataCommand(): Command {
       try {
         records = readJsonl(file);
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -8,6 +8,7 @@ import { checkMemory } from "../inference/memory-gate.js";
 import { getModelEntry } from "../models/inspector.js";
 import { capturePrompt } from "../adaptors/prompt-log.js";
 import { cleanGeneratedOutput } from "../eval/runner.js";
+import { ui, MascotSpinner, Spinner } from "../ui/index.js";
 
 function collectStrings(val: string, acc: string[]): string[] {
   return [...acc, val];
@@ -42,8 +43,8 @@ export function createGenerateCommand(): Command {
           const model = options.model ?? (config.default_model || undefined);
 
           if (!model) {
-            process.stderr.write(
-              "Error: no model specified. Use --model <path> or set default_model in config (coder config set default_model <path>)\n",
+            ui.error(
+              "no model specified. Use --model <path> or set default_model in config (coder config set default_model <path>)",
             );
             process.exit(1);
           }
@@ -96,16 +97,27 @@ export function createGenerateCommand(): Command {
 
           let result;
           if (options.stream === true && !dryRun) {
+            // Show dancing mascot while waiting for first token (TTFT gap)
+            const mascot = new MascotSpinner("Generating").start();
             const { stream, result: resultPromise } = runMlxStream(runOptions);
             const reader = stream.getReader();
+            let firstToken = true;
             for (;;) {
               const { done, value } = await reader.read();
               if (done) break;
+              if (firstToken) {
+                mascot.stop();
+                firstToken = false;
+              }
               process.stdout.write(value);
             }
+            if (firstToken) mascot.stop(); // dry-run or empty output
             result = await resultPromise;
           } else {
+            // Buffered mode: plain spinner while waiting
+            const spinner = new Spinner("Generating").start();
             result = await runMlxBuffered(runOptions);
+            spinner.stop();
             const cleaned = cleanGeneratedOutput(result.generatedText);
             if (options.output) {
               writeFileSync(options.output, cleaned);
@@ -137,17 +149,12 @@ export function createGenerateCommand(): Command {
           }
 
           if (result.tokensPerSecond !== undefined) {
-            process.stderr.write(
-              `Generation: ${String(result.tokensPerSecond)} tokens/sec\n`,
-            );
+            ui.dim(`Generation: ${String(result.tokensPerSecond)} tokens/sec`);
           }
         } catch (err) {
-          process.stderr.write(
-            `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-          );
+          ui.error(err instanceof Error ? err.message : String(err));
           process.exit(1);
         }
       },
     );
 }
-

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { loadConfig } from "../config/loader.js";
 import { listModels, getModelEntry } from "../models/inspector.js";
 import { pullModel } from "../models/pull.js";
+import { ui, renderTable } from "../ui/index.js";
 
 function formatBytes(bytes: number): string {
   if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)} GB`;
@@ -30,16 +31,18 @@ export function createModelsCommand(): Command {
       const modelsDir = getModelsDir();
       const entries = listModels(modelsDir);
 
-      const header = `${"NAME".padEnd(55)} ${"QUANT".padEnd(7)} ${"DISK".padEnd(10)} MEMORY`;
-      process.stdout.write(header + "\n");
+      const rows = entries.map((e) => [
+        e.name,
+        `${String(e.quantBits)}-bit`,
+        formatBytes(e.diskSizeBytes),
+        formatBytes(e.memoryEstimateGb * 1e9),
+      ]);
 
-      for (const entry of entries) {
-        const quant = `${String(entry.quantBits)}-bit`;
-        const disk = formatBytes(entry.diskSizeBytes);
-        const memory = formatBytes(entry.memoryEstimateGb * 1e9);
-        const line = `${entry.name.padEnd(55)} ${quant.padEnd(7)} ${disk.padEnd(10)} ${memory}\n`;
-        process.stdout.write(line);
-      }
+      process.stdout.write(renderTable(
+        ["NAME", "QUANT", "DISK", "MEMORY"],
+        rows,
+        { align: ["left", "left", "right", "right"] },
+      ));
     });
 
   cmd
@@ -50,7 +53,7 @@ export function createModelsCommand(): Command {
       const modelDir = resolveModelDir(modelsDir, name);
 
       if (!existsSync(modelDir)) {
-        process.stderr.write(`Error: model "${name}" not found in ${modelsDir}\n`);
+        ui.error(`model "${name}" not found in ${modelsDir}`);
         process.exit(1);
       }
 
@@ -70,12 +73,12 @@ export function createModelsCommand(): Command {
       const modelDir = resolveModelDir(modelsDir, name);
 
       if (!existsSync(modelDir)) {
-        process.stderr.write(`Error: model "${name}" not found in ${modelsDir}\n`);
+        ui.error(`model "${name}" not found in ${modelsDir}`);
         process.exit(1);
       }
 
       rmSync(modelDir, { recursive: true, force: true });
-      process.stdout.write(`Removed ${name}\n`);
+      ui.success(`Removed ${name}`);
     });
 
   cmd
@@ -86,9 +89,7 @@ export function createModelsCommand(): Command {
       try {
         await pullModel(repoId, modelsDir);
       } catch (err) {
-        process.stderr.write(
-          `Error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
+        ui.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
     });

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -40,6 +40,8 @@ export interface EvalOptions {
   adaptorPath?: string;
   inputFile?: string;
   dryRun: boolean;
+  /** Called after each record is evaluated.  `current` is 1-based. */
+  onProgress?: (current: number, total: number, prompt: string) => void;
 }
 
 interface JsonlRecord {
@@ -451,8 +453,10 @@ export async function runEval(
   const evalSuiteFile = join(adaptorDir, "evals", "eval_suite.ts");
 
   const evalRecords: EvalRecord[] = [];
+  const totalRecords = records.length;
 
-  for (const record of records) {
+  for (let recIdx = 0; recIdx < totalRecords; recIdx++) {
+    const record = records[recIdx] as JsonlRecord;
     const { generatedText } = await runMlxBuffered({
       model: opts.modelPath,
       prompt: record.prompt,
@@ -503,6 +507,8 @@ export async function runEval(
         tests: testsResult.output,
       },
     });
+
+    opts.onProgress?.(recIdx + 1, totalRecords, record.prompt);
   }
 
   return {

--- a/src/models/pull.ts
+++ b/src/models/pull.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
+import { ui, ByteProgress } from "../ui/index.js";
 
 interface HfSibling {
   rfilename: string;
@@ -32,20 +33,6 @@ export async function streamFileToPath(
   }
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)} GB`;
-  if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(0)} MB`;
-  return `${(bytes / 1e3).toFixed(0)} KB`;
-}
-
-function progressLine(filename: string, received: number, total: number): string {
-  if (total > 0) {
-    const pct = Math.floor((received / total) * 100);
-    return `\r  ${filename}  ${formatBytes(received)} / ${formatBytes(total)}  ${String(pct)}%   `;
-  }
-  return `\r  ${filename}  ${formatBytes(received)}`;
-}
-
 export async function pullModel(repoId: string, modelsDir: string): Promise<void> {
   if (process.env.CODER_DRY_RUN === "1") {
     process.stdout.write(`[dry-run] would pull ${repoId} into ${modelsDir}\n`);
@@ -70,6 +57,8 @@ export async function pullModel(repoId: string, modelsDir: string): Promise<void
   const modelDir = join(modelsDir, repoId);
   mkdirSync(modelDir, { recursive: true });
 
+  ui.divider(`Pulling model ${repoId}`);
+
   for (const { rfilename } of files) {
     const fileUrl = `https://huggingface.co/${repoId}/resolve/main/${rfilename}`;
     const destPath = join(modelDir, rfilename);
@@ -80,14 +69,14 @@ export async function pullModel(repoId: string, modelsDir: string): Promise<void
       throw new Error(`Failed to download ${rfilename}: ${String(fileResponse.status)}`);
     }
 
-    process.stderr.write(`  ${rfilename}\n`);
+    const progress = new ByteProgress(basename(rfilename));
 
     await streamFileToPath(fileResponse, destPath, (received, total) => {
-      process.stderr.write(progressLine(rfilename, received, total));
+      progress.update(received, total);
     });
 
-    process.stderr.write("\n");
+    progress.done();
   }
 
-  process.stdout.write(`\nModel ${repoId} downloaded to ${modelDir}\n`);
+  ui.success(`Model ${repoId} downloaded to ${modelDir}`);
 }

--- a/src/training/runner.ts
+++ b/src/training/runner.ts
@@ -12,6 +12,7 @@ import { checkPreflight } from "../inference/mlx-runner.js";
 import { logger } from "../observability/logger.js";
 import { generateLoraYaml } from "./config.js";
 import type { TrainConfig } from "./config.js";
+import { sparkline } from "../ui/index.js";
 
 export class TrainingDivergedError extends Error {
   constructor(public readonly lossAtAbort: number, public readonly iterAtAbort: number) {
@@ -109,6 +110,7 @@ export async function runMlxTrain(
   let finalLoss: number | undefined;
   let stdoutOutput = "";
   const recentLosses: number[] = []; // rolling window for divergence detection
+  const lossHistory: number[] = []; // for sparkline display
 
   for (;;) {
     const { done, value } = await reader.read();
@@ -121,10 +123,16 @@ export async function runMlxTrain(
     lineBuffer = lines.pop() ?? "";
 
     for (const line of lines) {
-      process.stderr.write(line + "\n");
       const parsed = parseLossLine(line);
       if (parsed) {
         finalLoss = parsed.loss;
+        lossHistory.push(parsed.loss);
+
+        // Sparkline from the last 16 data points
+        const spark = sparkline(lossHistory.slice(-16));
+        process.stderr.write(
+          `  Iter ${String(parsed.iter).padStart(4)}  loss ${parsed.loss.toFixed(4)}  ${spark}\n`,
+        );
 
         // #43: detect divergence — accumulate all losses, but only check after iter 20
         recentLosses.push(parsed.loss);

--- a/src/ui/ansi.ts
+++ b/src/ui/ansi.ts
@@ -1,0 +1,68 @@
+// ANSI escape code primitives.
+// All color/cursor operations go through these constants so they're
+// easy to strip in tests and non-TTY environments.
+
+export const RESET     = "\x1b[0m";
+export const BOLD      = "\x1b[1m";
+export const DIM       = "\x1b[2m";
+export const RED       = "\x1b[31m";
+export const GREEN     = "\x1b[32m";
+export const YELLOW    = "\x1b[33m";
+export const BLUE      = "\x1b[34m";
+export const MAGENTA   = "\x1b[35m";
+export const CYAN      = "\x1b[36m";
+export const WHITE     = "\x1b[37m";
+
+// Cursor / line control
+export const CLEAR_LINE   = "\x1b[2K\r";     // erase current line + carriage return
+export const ERASE_EOL    = "\x1b[K";        // erase from cursor to end of line
+export const HIDE_CURSOR  = "\x1b[?25l";
+export const SHOW_CURSOR  = "\x1b[?25h";
+
+/** Move cursor up N lines. */
+export function cursorUp(n: number): string {
+  return `\x1b[${String(n)}A`;
+}
+
+/**
+ * Wrap `text` with the given ANSI codes and append RESET.
+ * Returns the plain text unchanged when `isTTY` is false.
+ */
+export function wrap(text: string, isTTY: boolean, ...codes: string[]): string {
+  if (!isTTY || codes.length === 0) return text;
+  return `${codes.join("")}${text}${RESET}`;
+}
+
+/**
+ * Strip all ANSI escape sequences from a string.
+ * Useful for normalising test assertions.
+ */
+export function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "");
+}
+
+// Sparkline bars — maps a normalised 0–1 value to a block character.
+const SPARKLINE_BARS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
+
+/**
+ * Render an array of numbers as a sparkline string using block characters.
+ * All values are normalised to the range [min, max] within the array.
+ * Returns an empty string for an empty input.
+ */
+export function sparkline(values: number[]): string {
+  if (values.length === 0) return "";
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  return values
+    .map((v) => {
+      if (range === 0) return SPARKLINE_BARS[0];
+      const idx = Math.min(
+        SPARKLINE_BARS.length - 1,
+        Math.floor(((v - min) / range) * SPARKLINE_BARS.length),
+      );
+      return SPARKLINE_BARS[idx];
+    })
+    .join("");
+}

--- a/src/ui/context.ts
+++ b/src/ui/context.ts
@@ -1,0 +1,36 @@
+/**
+ * UiContext — global settings for all terminal UI components.
+ *
+ * Initialised once at CLI startup via `initUiContext()`, then read by
+ * every spinner/progress/print helper.  Tests reset via `resetUiContextForTest()`.
+ */
+
+export interface UiContext {
+  /** Suppress all progress/status output (for scripting / --quiet flag). */
+  quiet: boolean;
+  /** Whether stderr is a real TTY (enables animations, colours, cursor moves). */
+  isTTY: boolean;
+  /** CODER_DRY_RUN=1 — suppress animations (process won't actually do anything). */
+  dryRun: boolean;
+}
+
+const DEFAULT_CONTEXT: UiContext = {
+  quiet:  false,
+  isTTY:  process.stderr.isTTY === true,
+  dryRun: process.env.CODER_DRY_RUN === "1",
+};
+
+// Mutable singleton — all UI components reference this object directly.
+export const uiCtx: UiContext = { ...DEFAULT_CONTEXT };
+
+/** Merge partial overrides into the singleton.  Called once at CLI startup. */
+export function initUiContext(opts: Partial<UiContext>): void {
+  Object.assign(uiCtx, opts);
+}
+
+/** Reset to defaults + re-detect TTY/dryRun.  For use in tests only. */
+export function resetUiContextForTest(): void {
+  uiCtx.quiet  = false;
+  uiCtx.isTTY  = process.stderr.isTTY === true;
+  uiCtx.dryRun = process.env.CODER_DRY_RUN === "1";
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,37 @@
+/**
+ * src/ui — Public API surface for the CLI terminal UX framework.
+ *
+ * Import from here rather than individual modules:
+ *   import { Spinner, MascotSpinner, ByteProgress, StepProgress, renderTable, ui, sparkline } from "../ui/index.js";
+ */
+
+export { uiCtx, initUiContext, resetUiContextForTest } from "./context.js";
+export type { UiContext } from "./context.js";
+
+export { Spinner } from "./spinner.js";
+export { MascotSpinner } from "./mascot.js";
+export { ByteProgress, StepProgress } from "./progress.js";
+export { renderTable } from "./table.js";
+export type { TableOptions, Alignment } from "./table.js";
+export { sparkline, stripAnsi, wrap } from "./ansi.js";
+
+import * as _print from "./print.js";
+
+/**
+ * `ui` namespace — convenience accessor for all print helpers.
+ *
+ * Usage:
+ *   import { ui } from "../ui/index.js";
+ *   ui.info("Loading model...");
+ *   ui.error("Not found");
+ */
+export const ui = {
+  info:     _print.info,
+  warn:     _print.warn,
+  error:    _print.error,
+  success:  _print.success,
+  dim:      _print.dim,
+  out:      _print.out,
+  divider:  _print.divider,
+  scoreDelta: _print.scoreDelta,
+} as const;

--- a/src/ui/mascot.ts
+++ b/src/ui/mascot.ts
@@ -1,0 +1,163 @@
+/**
+ * MascotSpinner — "Spark" the coder bot.
+ *
+ * A multi-line animated ASCII mascot that dances while generation / inference
+ * is running.  Falls back to plain single-line Spinner behaviour in non-TTY,
+ * quiet, or dry-run mode.
+ *
+ * TTY mode: renders a 4-line ASCII figure + 1-line status bar.
+ * On each tick the figure cycles through 6 frames and the status bar shows
+ * the spinner glyph, label, and elapsed time.
+ */
+
+import { Spinner } from "./spinner.js";
+import { uiCtx } from "./context.js";
+import {
+  cursorUp, ERASE_EOL, CLEAR_LINE, HIDE_CURSOR, SHOW_CURSOR,
+  wrap, BOLD, CYAN, GREEN, RED,
+} from "./ansi.js";
+
+// ---------------------------------------------------------------------------
+// "Spark" — 6-frame dancing robot.  Each frame is exactly 4 lines.
+// ---------------------------------------------------------------------------
+const SPARK_FRAMES: ReadonlyArray<readonly string[]> = [
+  // 0 — idle / neutral
+  [
+    "   .─.   ",
+    "  (o_o)  ",
+    "   )=(   ",
+    "  /   \\  ",
+  ],
+  // 1 — right arm up
+  [
+    "   .─.   ",
+    "  (^_o)╱ ",
+    "   )=(   ",
+    "  /   \\  ",
+  ],
+  // 2 — both arms up
+  [
+    "   .─.   ",
+    " ╲(^_^)╱ ",
+    "   )=(   ",
+    "   | |   ",
+  ],
+  // 3 — left arm up
+  [
+    "   .─.   ",
+    " ╲(o_^)  ",
+    "   )=(   ",
+    "  /   \\  ",
+  ],
+  // 4 — excited
+  [
+    "   .─.   ",
+    " ╲(◕_◕)╱ ",
+    "   )=(   ",
+    "  ╱   ╲  ",
+  ],
+  // 5 — thinking
+  [
+    "   .─.   ",
+    "  (._.)  ",
+    "   )=(   ",
+    "   | |   ",
+  ],
+] as const;
+
+const BODY_LINES = SPARK_FRAMES[0].length;   // 4
+const TOTAL_LINES = BODY_LINES + 1;           // +1 for status bar
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const INTERVAL_MS = 120;
+
+export class MascotSpinner extends Spinner {
+  private _mascotTimer: ReturnType<typeof setInterval> | null = null;
+  private _mascotFrame = 0;
+  private _initialised = false;
+
+  override start(): this {
+    if (uiCtx.quiet || uiCtx.dryRun) return this;
+
+    if (!uiCtx.isTTY) {
+      // Non-TTY: delegate to parent (single-line text)
+      return super.start();
+    }
+
+    // TTY: render mascot
+    this._initialised = false;
+    process.stderr.write(HIDE_CURSOR);
+    this._renderMascot();
+    this._initialised = true;
+    this._mascotTimer = setInterval(() => { this._renderMascot(); }, INTERVAL_MS);
+    return this;
+  }
+
+  override update(label: string): this {
+    this._label = label;
+    return this;
+  }
+
+  override succeed(label?: string): this {
+    if (!uiCtx.isTTY) return super.succeed(label);
+    this._stopMascot();
+    if (uiCtx.quiet || uiCtx.dryRun) return this;
+    const msg = label ?? this._label;
+    process.stderr.write(`${wrap("✓", uiCtx.isTTY, BOLD, GREEN)} ${msg}\n`);
+    return this;
+  }
+
+  override fail(label?: string): this {
+    if (!uiCtx.isTTY) return super.fail(label);
+    this._stopMascot();
+    if (uiCtx.quiet || uiCtx.dryRun) return this;
+    const msg = label ?? this._label;
+    process.stderr.write(`${wrap("✗", uiCtx.isTTY, BOLD, RED)} ${msg}\n`);
+    return this;
+  }
+
+  override stop(): this {
+    if (!uiCtx.isTTY) return super.stop();
+    this._stopMascot();
+    return this;
+  }
+
+  // -------------------------------------------------------------------------
+
+  private _stopMascot(): void {
+    if (this._mascotTimer !== null) {
+      clearInterval(this._mascotTimer);
+      this._mascotTimer = null;
+    }
+    // Erase all mascot lines
+    if (uiCtx.isTTY && this._initialised) {
+      process.stderr.write(cursorUp(TOTAL_LINES));
+      for (let i = 0; i < TOTAL_LINES; i++) {
+        process.stderr.write(CLEAR_LINE + (i < TOTAL_LINES - 1 ? "\n" : ""));
+      }
+    }
+    process.stderr.write(SHOW_CURSOR);
+  }
+
+  private _renderMascot(): void {
+    const frame  = SPARK_FRAMES[this._mascotFrame % SPARK_FRAMES.length];
+    const glyphI = this._mascotFrame % SPINNER_FRAMES.length;
+    const glyph  = SPINNER_FRAMES[glyphI];
+    this._mascotFrame++;
+
+    const elapsed  = this._elapsed();
+    const statusLine = `  ${wrap(glyph, uiCtx.isTTY, BOLD, CYAN)}  ${this._label}  ${elapsed}`;
+
+    if (this._initialised) {
+      // Move up to top of previously rendered block
+      process.stderr.write(cursorUp(TOTAL_LINES));
+    }
+
+    for (const line of frame) {
+      process.stderr.write(
+        `${wrap(line, uiCtx.isTTY, BOLD, CYAN)}${ERASE_EOL}\n`,
+      );
+    }
+    process.stderr.write(`${statusLine}${ERASE_EOL}\n`);
+  }
+}

--- a/src/ui/print.ts
+++ b/src/ui/print.ts
@@ -1,0 +1,73 @@
+/**
+ * Consistent terminal print helpers.
+ *
+ * All functions respect `uiCtx.quiet` (except `ui.out` which is data output).
+ * Colours are stripped automatically when `uiCtx.isTTY` is false.
+ *
+ * Progress/status goes to **stderr**; data output goes to **stdout**.
+ */
+
+import { uiCtx } from "./context.js";
+import { wrap, BOLD, CYAN, YELLOW, RED, GREEN, DIM, RESET } from "./ansi.js";
+
+function stderr(msg: string): void {
+  process.stderr.write(msg + "\n");
+}
+
+/** [INFO] message — cyan prefix, to stderr.  Suppressed when quiet. */
+export function info(msg: string): void {
+  if (uiCtx.quiet) return;
+  stderr(`${wrap("[INFO]", uiCtx.isTTY, BOLD, CYAN)} ${msg}`);
+}
+
+/** [WARN] message — yellow prefix, to stderr.  Suppressed when quiet. */
+export function warn(msg: string): void {
+  if (uiCtx.quiet) return;
+  stderr(`${wrap("[WARN]", uiCtx.isTTY, BOLD, YELLOW)} ${msg}`);
+}
+
+/** [ERROR] message — red prefix, to stderr.  Always shown (ignores quiet). */
+export function error(msg: string): void {
+  stderr(`${wrap("[ERROR]", uiCtx.isTTY, BOLD, RED)} ${msg}`);
+}
+
+/** ✓ message — green, to stderr.  Suppressed when quiet. */
+export function success(msg: string): void {
+  if (uiCtx.quiet) return;
+  stderr(`${wrap("✓", uiCtx.isTTY, BOLD, GREEN)} ${msg}`);
+}
+
+/** Dim message — to stderr.  Suppressed when quiet. */
+export function dim(msg: string): void {
+  if (uiCtx.quiet) return;
+  stderr(wrap(msg, uiCtx.isTTY, DIM));
+}
+
+/**
+ * Data output — always written to **stdout**, never suppressed.
+ * Use for generated code, config values, lists, etc.
+ */
+export function out(msg: string): void {
+  process.stdout.write(msg);
+}
+
+/** Section divider — cyan dashes, to stderr.  Suppressed when quiet. */
+export function divider(label?: string): void {
+  if (uiCtx.quiet) return;
+  if (label) {
+    const dashes = "╌".repeat(3);
+    const line = `${dashes} ${label} ${dashes}`;
+    stderr(wrap(line, uiCtx.isTTY, BOLD, CYAN));
+  } else {
+    stderr(wrap("─".repeat(48), uiCtx.isTTY, DIM));
+  }
+}
+
+/** Coloured score delta, e.g. "+0.042" in green or "−0.018" in red. */
+export function scoreDelta(delta: number): string {
+  const sign   = delta >= 0 ? "+" : "";
+  const text   = `${sign}${delta.toFixed(3)}`;
+  if (!uiCtx.isTTY) return text;
+  const code   = delta >= 0 ? `${BOLD}${GREEN}` : `${BOLD}${RED}`;
+  return `${code}${text}${RESET}`;
+}

--- a/src/ui/progress.ts
+++ b/src/ui/progress.ts
@@ -1,0 +1,145 @@
+/**
+ * Progress indicators for long-running operations.
+ *
+ * ByteProgress  — file download with speed (MB/s) and ETA.
+ * StepProgress  — N-of-M loop with a fill bar (e.g. eval prompts).
+ *
+ * Both:
+ *   - Write to stderr using carriage-return (\r) for in-place updates in TTY.
+ *   - Print each step on its own line in non-TTY mode (no cursor tricks).
+ *   - Are silent when `uiCtx.quiet` is true.
+ */
+
+import { uiCtx } from "./context.js";
+import { wrap, BOLD, GREEN, CYAN, DIM, RESET, ERASE_EOL } from "./ansi.js";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(2)} GB`;
+  if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(1)} MB`;
+  return `${(bytes / 1e3).toFixed(0)} KB`;
+}
+
+function renderBar(ratio: number, width = 20): string {
+  const filled = Math.round(ratio * width);
+  const empty  = width - filled;
+  return (
+    wrap("█".repeat(filled), uiCtx.isTTY, BOLD, GREEN) +
+    wrap("░".repeat(empty), uiCtx.isTTY, DIM)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ByteProgress
+// ---------------------------------------------------------------------------
+
+export class ByteProgress {
+  private _filename: string;
+  private _startMs: number;
+  /** Ring-buffer of (timestamp, bytes) for rolling-window speed calc. */
+  private _window: Array<[number, number]> = [];
+
+  constructor(filename: string) {
+    this._filename = filename;
+    this._startMs  = Date.now();
+  }
+
+  /** Call each time a chunk arrives. `total` = 0 means unknown. */
+  update(received: number, total: number): void {
+    if (uiCtx.quiet) return;
+
+    const now = Date.now();
+    this._window.push([now, received]);
+    // Keep ~2 s of history
+    const cutoff = now - 2000;
+    while (this._window.length > 1 && (this._window[0]?.[0] ?? 0) < cutoff) {
+      this._window.shift();
+    }
+
+    const pct    = total > 0 ? received / total : 0;
+    const bar    = total > 0 ? `[${renderBar(pct)}] ` : "";
+    const pctStr = total > 0 ? `${String(Math.floor(pct * 100)).padStart(3)}%  ` : "";
+
+    // Speed over rolling window
+    let speedStr = "";
+    let etaStr   = "";
+    if (this._window.length >= 2) {
+      const oldest = this._window[0];
+      const newest = this._window[this._window.length - 1];
+      if (oldest && newest) {
+        const dt    = (newest[0] - oldest[0]) / 1000;
+        const db    = newest[1] - oldest[1];
+        const bps   = dt > 0 ? db / dt : 0;
+        speedStr    = `  ${formatBytes(bps)}/s`;
+
+        if (total > 0 && bps > 0) {
+          const remaining = total - received;
+          const etaSec    = remaining / bps;
+          etaStr = `  ETA ${etaSec < 60 ? `${Math.round(etaSec)}s` : `${Math.round(etaSec / 60)}m`}`;
+        }
+      }
+    }
+
+    const name = this._filename.length > 28
+      ? `…${this._filename.slice(-27)}`
+      : this._filename.padEnd(28);
+
+    const line = `  ${name}  ${bar}${pctStr}${formatBytes(received)}${total > 0 ? ` / ${formatBytes(total)}` : ""}${speedStr}${etaStr}`;
+
+    if (uiCtx.isTTY) {
+      process.stderr.write(`\r${line}${ERASE_EOL}`);
+    } else {
+      process.stderr.write(`${line}\n`);
+    }
+  }
+
+  /** Call when the file download is complete. */
+  done(): void {
+    if (uiCtx.quiet) return;
+    const elapsed = ((Date.now() - this._startMs) / 1000).toFixed(1);
+    if (uiCtx.isTTY) process.stderr.write("\n");
+    process.stderr.write(
+      `  ${wrap("✓", uiCtx.isTTY, BOLD, GREEN)} ${this._filename}  (${elapsed}s)\n`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StepProgress
+// ---------------------------------------------------------------------------
+
+export class StepProgress {
+  private _label: string;
+
+  constructor(label: string) {
+    this._label = label;
+  }
+
+  /** `current` is 1-based. */
+  tick(current: number, total: number, detail?: string): void {
+    if (uiCtx.quiet) return;
+    const ratio   = total > 0 ? current / total : 0;
+    const bar     = `[${renderBar(ratio, 16)}]`;
+    const counter = `${wrap(`[${String(current)}/${String(total)}]`, uiCtx.isTTY, BOLD, CYAN)}`;
+    const detailStr = detail ? `  ${wrap(detail, uiCtx.isTTY, DIM)}` : "";
+    const line    = `  ${this._label} ${counter}  ${bar}  ${String(Math.round(ratio * 100))}%${detailStr}`;
+
+    if (uiCtx.isTTY) {
+      process.stderr.write(`\r${line}${ERASE_EOL}`);
+    } else {
+      process.stderr.write(`${line}\n`);
+    }
+  }
+
+  /** Clear the progress line and print a summary. */
+  done(summary: string): void {
+    if (uiCtx.quiet) return;
+    if (uiCtx.isTTY) process.stderr.write("\n");
+    process.stderr.write(
+      `  ${wrap("✓", uiCtx.isTTY, BOLD, GREEN)} ${summary}\n`,
+    );
+  }
+}

--- a/src/ui/spinner.ts
+++ b/src/ui/spinner.ts
@@ -1,0 +1,97 @@
+/**
+ * Single-line animated spinner.
+ *
+ * TTY mode   — Braille frames tick at 80 ms; cursor hidden while running.
+ * Non-TTY    — `start()` prints `label...` once; succeed/fail print result once.
+ * quiet/dryRun — all methods are no-ops.
+ */
+
+import { uiCtx } from "./context.js";
+import {
+  CLEAR_LINE, HIDE_CURSOR, SHOW_CURSOR, ERASE_EOL,
+  wrap, BOLD, GREEN, RED, CYAN,
+} from "./ansi.js";
+
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const INTERVAL_MS = 80;
+
+export class Spinner {
+  protected _label: string;
+  private _frameIdx = 0;
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _startMs = 0;
+
+  constructor(label: string) {
+    this._label = label;
+  }
+
+  get label(): string { return this._label; }
+
+  start(): this {
+    if (uiCtx.quiet || uiCtx.dryRun) return this;
+
+    this._startMs = Date.now();
+
+    if (uiCtx.isTTY) {
+      process.stderr.write(HIDE_CURSOR);
+      this._tick();
+      this._timer = setInterval(() => { this._tick(); }, INTERVAL_MS);
+    } else {
+      process.stderr.write(`${this._label}...\n`);
+    }
+    return this;
+  }
+
+  update(label: string): this {
+    this._label = label;
+    return this;
+  }
+
+  succeed(label?: string): this {
+    this._stop();
+    if (uiCtx.quiet || uiCtx.dryRun) return this;
+    const msg = label ?? this._label;
+    process.stderr.write(`${wrap("✓", uiCtx.isTTY, BOLD, GREEN)} ${msg}\n`);
+    return this;
+  }
+
+  fail(label?: string): this {
+    this._stop();
+    if (uiCtx.quiet || uiCtx.dryRun) return this;
+    const msg = label ?? this._label;
+    process.stderr.write(`${wrap("✗", uiCtx.isTTY, BOLD, RED)} ${msg}\n`);
+    return this;
+  }
+
+  stop(): this {
+    this._stop();
+    if (uiCtx.isTTY && !uiCtx.quiet && !uiCtx.dryRun) {
+      process.stderr.write(CLEAR_LINE);
+    }
+    return this;
+  }
+
+  protected _stop(): void {
+    if (this._timer !== null) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+    if (uiCtx.isTTY) {
+      process.stderr.write(SHOW_CURSOR);
+      process.stderr.write(CLEAR_LINE);
+    }
+  }
+
+  protected _elapsed(): string {
+    const ms = Date.now() - this._startMs;
+    return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${String(ms)}ms`;
+  }
+
+  private _tick(): void {
+    const frame = FRAMES[this._frameIdx % FRAMES.length];
+    this._frameIdx++;
+    const elapsed = this._elapsed();
+    const line = `${wrap(frame, uiCtx.isTTY, BOLD, CYAN)}  ${this._label}  ${elapsed}${ERASE_EOL}`;
+    process.stderr.write(`\r${line}`);
+  }
+}

--- a/src/ui/table.ts
+++ b/src/ui/table.ts
@@ -1,0 +1,73 @@
+/**
+ * Consistent table renderer.
+ *
+ * Replaces the hand-rolled `.padEnd()` pattern used across commands.
+ * Returns a fully-formed string (caller writes it to stdout/stderr).
+ *
+ * Headers are rendered in bold when isTTY.
+ * A `─` separator row is drawn under the headers.
+ * Numeric columns are right-aligned; all others are left-aligned.
+ */
+
+import { uiCtx } from "./context.js";
+import { wrap, BOLD, DIM, RESET } from "./ansi.js";
+
+export type Alignment = "left" | "right";
+
+export interface TableOptions {
+  /** Explicit column widths.  If omitted, derived from content. */
+  widths?: number[];
+  /** Per-column alignment.  Defaults to "left". */
+  align?: Alignment[];
+}
+
+/**
+ * Render a table to a string.
+ *
+ * @param headers  Column header labels.
+ * @param rows     Data rows.  Each inner array must have the same length as `headers`.
+ * @param opts     Optional column widths and alignment.
+ */
+export function renderTable(
+  headers: string[],
+  rows: string[][],
+  opts: TableOptions = {},
+): string {
+  const colCount = headers.length;
+
+  // Compute column widths
+  const widths: number[] = headers.map((h, i) => {
+    if (opts.widths?.[i] !== undefined) return opts.widths[i];
+    const maxData = rows.reduce((m, row) => Math.max(m, (row[i] ?? "").length), 0);
+    return Math.max(h.length, maxData);
+  });
+
+  const align: Alignment[] = headers.map((_, i) => opts.align?.[i] ?? "left");
+
+  function pad(text: string, width: number, a: Alignment): string {
+    if (a === "right") return text.padStart(width);
+    return text.padEnd(width);
+  }
+
+  const lines: string[] = [];
+
+  // Header row
+  const headerCells = headers.map((h, i) =>
+    wrap(pad(h, widths[i], align[i]), uiCtx.isTTY, BOLD),
+  );
+  lines.push("  " + headerCells.join("  "));
+
+  // Separator
+  const sepCells = widths.map((w) => wrap("─".repeat(w), uiCtx.isTTY, DIM));
+  lines.push("  " + sepCells.join("  "));
+
+  // Data rows
+  for (const row of rows) {
+    const cells = headers.map((_, i) =>
+      pad(row[i] ?? "", widths[i], align[i]),
+    );
+    lines.push("  " + cells.join("  "));
+  }
+
+  return lines.join("\n") + "\n";
+}

--- a/tests/unit/ui-ansi.test.ts
+++ b/tests/unit/ui-ansi.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test";
+import { wrap, stripAnsi, sparkline, BOLD, GREEN, RED, RESET } from "../../src/ui/ansi.js";
+
+describe("wrap", () => {
+  test("wraps text with codes when isTTY=true", () => {
+    const result = wrap("hello", true, BOLD, GREEN);
+    expect(result).toBe(`${BOLD}${GREEN}hello${RESET}`);
+  });
+
+  test("returns plain text when isTTY=false", () => {
+    expect(wrap("hello", false, BOLD, GREEN)).toBe("hello");
+  });
+
+  test("returns plain text when no codes given", () => {
+    expect(wrap("hello", true)).toBe("hello");
+  });
+});
+
+describe("stripAnsi", () => {
+  test("strips escape sequences", () => {
+    const withAnsi = `${BOLD}${GREEN}hello${RESET}`;
+    expect(stripAnsi(withAnsi)).toBe("hello");
+  });
+
+  test("leaves plain strings unchanged", () => {
+    expect(stripAnsi("plain text")).toBe("plain text");
+  });
+
+  test("strips cursor/erase codes but not carriage return", () => {
+    // \x1b[2K and \x1b[K are ANSI sequences; \r is a plain control character
+    expect(stripAnsi("\x1b[2Khello\x1b[K")).toBe("hello");
+  });
+});
+
+describe("sparkline", () => {
+  test("returns empty string for empty array", () => {
+    expect(sparkline([])).toBe("");
+  });
+
+  test("returns a single low bar when all values equal", () => {
+    expect(sparkline([5, 5, 5])).toBe("▁▁▁");
+  });
+
+  test("maps min to ▁ and max to █", () => {
+    const result = sparkline([0, 1]);
+    expect(result[0]).toBe("▁");
+    expect(result[1]).toBe("█");
+  });
+
+  test("length matches input length", () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8];
+    expect(sparkline(values)).toHaveLength(values.length);
+  });
+
+  test("monotone increasing produces ascending bars", () => {
+    const result = sparkline([1, 2, 3, 4, 5, 6, 7, 8]);
+    // Each character should be >= previous (non-decreasing)
+    for (let i = 1; i < result.length; i++) {
+      expect(result.charCodeAt(i)).toBeGreaterThanOrEqual(result.charCodeAt(i - 1));
+    }
+  });
+});

--- a/tests/unit/ui-mascot.test.ts
+++ b/tests/unit/ui-mascot.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { initUiContext, resetUiContextForTest } from "../../src/ui/context.js";
+import { MascotSpinner } from "../../src/ui/mascot.js";
+import { stripAnsi } from "../../src/ui/ansi.js";
+
+let stderrLines: string[] = [];
+
+function captured(): string {
+  return stderrLines.map(stripAnsi).join("");
+}
+
+beforeEach(() => {
+  resetUiContextForTest();
+  // Non-TTY: MascotSpinner delegates to Spinner behaviour
+  initUiContext({ isTTY: false });
+  stderrLines = [];
+  spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderrLines.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  resetUiContextForTest();
+});
+
+describe("MascotSpinner — non-TTY degrades to Spinner", () => {
+  test("start() prints label...", () => {
+    new MascotSpinner("Generating").start();
+    expect(captured()).toContain("Generating...");
+  });
+
+  test("succeed() prints ✓ and label", () => {
+    const m = new MascotSpinner("Generating");
+    m.start();
+    stderrLines = [];
+    m.succeed("First token received");
+    expect(captured()).toContain("✓");
+    expect(captured()).toContain("First token received");
+  });
+
+  test("fail() prints ✗ and label", () => {
+    const m = new MascotSpinner("Generating");
+    m.start();
+    stderrLines = [];
+    m.fail("timed out");
+    expect(captured()).toContain("✗");
+    expect(captured()).toContain("timed out");
+  });
+
+  test("update() then succeed uses new label", () => {
+    const m = new MascotSpinner("Waiting");
+    m.start();
+    m.update("Streaming");
+    stderrLines = [];
+    m.succeed();
+    expect(captured()).toContain("Streaming");
+  });
+});
+
+describe("MascotSpinner — quiet mode", () => {
+  test("all methods are no-ops when quiet=true", () => {
+    initUiContext({ quiet: true });
+    const m = new MascotSpinner("Task");
+    m.start();
+    m.succeed("done");
+    m.fail("fail");
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("MascotSpinner — dryRun mode", () => {
+  test("start() is a no-op when dryRun=true", () => {
+    initUiContext({ dryRun: true });
+    new MascotSpinner("Task").start();
+    expect(stderrLines).toHaveLength(0);
+  });
+});

--- a/tests/unit/ui-print.test.ts
+++ b/tests/unit/ui-print.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { initUiContext, resetUiContextForTest } from "../../src/ui/context.js";
+import { stripAnsi } from "../../src/ui/ansi.js";
+
+// Import print functions fresh each test via the module
+import { info, warn, error, success, dim, out, divider, scoreDelta } from "../../src/ui/print.js";
+
+// Capture stderr/stdout writes
+let stderrLines: string[] = [];
+let stdoutLines: string[] = [];
+
+beforeEach(() => {
+  resetUiContextForTest();
+  initUiContext({ isTTY: false }); // deterministic: no ANSI codes in output
+  stderrLines = [];
+  stdoutLines = [];
+  spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderrLines.push(stripAnsi(String(chunk)));
+    return true;
+  });
+  spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    stdoutLines.push(stripAnsi(String(chunk)));
+    return true;
+  });
+});
+
+afterEach(() => {
+  resetUiContextForTest();
+});
+
+describe("ui.info", () => {
+  test("outputs [INFO] prefix to stderr", () => {
+    info("hello world");
+    expect(stderrLines.some((l) => l.includes("[INFO]") && l.includes("hello world"))).toBe(true);
+  });
+
+  test("suppressed when quiet=true", () => {
+    initUiContext({ quiet: true });
+    info("should be suppressed");
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("ui.warn", () => {
+  test("outputs [WARN] prefix to stderr", () => {
+    warn("something off");
+    expect(stderrLines.some((l) => l.includes("[WARN]") && l.includes("something off"))).toBe(true);
+  });
+
+  test("suppressed when quiet=true", () => {
+    initUiContext({ quiet: true });
+    warn("nope");
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("ui.error", () => {
+  test("outputs [ERROR] prefix to stderr", () => {
+    error("boom");
+    expect(stderrLines.some((l) => l.includes("[ERROR]") && l.includes("boom"))).toBe(true);
+  });
+
+  test("NOT suppressed when quiet=true (errors always show)", () => {
+    initUiContext({ quiet: true });
+    error("always visible");
+    expect(stderrLines.some((l) => l.includes("[ERROR]"))).toBe(true);
+  });
+});
+
+describe("ui.success", () => {
+  test("outputs ✓ to stderr", () => {
+    success("done");
+    expect(stderrLines.some((l) => l.includes("✓") && l.includes("done"))).toBe(true);
+  });
+
+  test("suppressed when quiet=true", () => {
+    initUiContext({ quiet: true });
+    success("done");
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("ui.dim", () => {
+  test("outputs message to stderr", () => {
+    dim("detail");
+    expect(stderrLines.some((l) => l.includes("detail"))).toBe(true);
+  });
+
+  test("suppressed when quiet=true", () => {
+    initUiContext({ quiet: true });
+    dim("detail");
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("ui.out", () => {
+  test("writes to stdout", () => {
+    out("output data\n");
+    expect(stdoutLines.some((l) => l.includes("output data"))).toBe(true);
+  });
+
+  test("never suppressed when quiet=true", () => {
+    initUiContext({ quiet: true });
+    out("data\n");
+    expect(stdoutLines.some((l) => l.includes("data"))).toBe(true);
+  });
+});
+
+describe("ui.divider", () => {
+  test("renders label between dashes", () => {
+    divider("Section");
+    expect(stderrLines.some((l) => l.includes("Section"))).toBe(true);
+  });
+
+  test("renders plain dashes with no label", () => {
+    divider();
+    expect(stderrLines.some((l) => l.includes("─"))).toBe(true);
+  });
+
+  test("suppressed when quiet=true", () => {
+    initUiContext({ quiet: true });
+    divider("hidden");
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("ui.scoreDelta", () => {
+  test("positive delta prefixed with +", () => {
+    const result = stripAnsi(scoreDelta(0.042));
+    expect(result).toBe("+0.042");
+  });
+
+  test("negative delta has − sign", () => {
+    const result = stripAnsi(scoreDelta(-0.018));
+    expect(result).toBe("-0.018");
+  });
+
+  test("zero is prefixed with +", () => {
+    const result = stripAnsi(scoreDelta(0));
+    expect(result).toBe("+0.000");
+  });
+});

--- a/tests/unit/ui-progress.test.ts
+++ b/tests/unit/ui-progress.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { initUiContext, resetUiContextForTest } from "../../src/ui/context.js";
+import { ByteProgress, StepProgress } from "../../src/ui/progress.js";
+import { stripAnsi } from "../../src/ui/ansi.js";
+
+let stderrLines: string[] = [];
+
+function lastLine(): string {
+  return stripAnsi(stderrLines[stderrLines.length - 1] ?? "");
+}
+
+function allOutput(): string {
+  return stderrLines.map(stripAnsi).join("");
+}
+
+beforeEach(() => {
+  resetUiContextForTest();
+  initUiContext({ isTTY: false }); // non-TTY: each update on its own line
+  stderrLines = [];
+  spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderrLines.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  resetUiContextForTest();
+});
+
+// ---------------------------------------------------------------------------
+// ByteProgress
+// ---------------------------------------------------------------------------
+
+describe("ByteProgress.update", () => {
+  test("shows percentage when total > 0", () => {
+    const p = new ByteProgress("model.safetensors");
+    p.update(500_000, 1_000_000);
+    expect(lastLine()).toContain("50%");
+  });
+
+  test("shows filename (truncated if long)", () => {
+    const p = new ByteProgress("weights.safetensors");
+    p.update(100_000, 1_000_000);
+    expect(lastLine()).toContain("weights");
+  });
+
+  test("shows received bytes without total when total=0", () => {
+    const p = new ByteProgress("file.bin");
+    p.update(2_000_000, 0);
+    expect(lastLine()).toContain("MB");
+  });
+
+  test("silent when quiet=true", () => {
+    initUiContext({ quiet: true });
+    const p = new ByteProgress("file.bin");
+    p.update(100, 1000);
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("ByteProgress.done", () => {
+  test("prints ✓ with filename", () => {
+    const p = new ByteProgress("model.safetensors");
+    p.update(1_000_000, 1_000_000);
+    stderrLines = [];
+    p.done();
+    expect(allOutput()).toContain("✓");
+    expect(allOutput()).toContain("model.safetensors");
+  });
+
+  test("silent when quiet=true", () => {
+    initUiContext({ quiet: true });
+    const p = new ByteProgress("file.bin");
+    p.done();
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StepProgress
+// ---------------------------------------------------------------------------
+
+describe("StepProgress.tick", () => {
+  test("shows current and total", () => {
+    const p = new StepProgress("Evaluating prompt");
+    p.tick(3, 5);
+    expect(lastLine()).toContain("3");
+    expect(lastLine()).toContain("5");
+  });
+
+  test("shows percentage", () => {
+    const p = new StepProgress("Evaluating prompt");
+    p.tick(2, 4);
+    expect(lastLine()).toContain("50%");
+  });
+
+  test("shows optional detail", () => {
+    const p = new StepProgress("Evaluating prompt");
+    p.tick(1, 5, "react/Button.tsx");
+    expect(lastLine()).toContain("react/Button.tsx");
+  });
+
+  test("silent when quiet=true", () => {
+    initUiContext({ quiet: true });
+    const p = new StepProgress("Eval");
+    p.tick(1, 5);
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("StepProgress.done", () => {
+  test("prints ✓ with summary", () => {
+    const p = new StepProgress("Eval");
+    p.tick(5, 5);
+    stderrLines = [];
+    p.done("5/5 prompts evaluated");
+    expect(allOutput()).toContain("✓");
+    expect(allOutput()).toContain("5/5 prompts evaluated");
+  });
+});

--- a/tests/unit/ui-spinner.test.ts
+++ b/tests/unit/ui-spinner.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { initUiContext, resetUiContextForTest } from "../../src/ui/context.js";
+import { Spinner } from "../../src/ui/spinner.js";
+import { stripAnsi } from "../../src/ui/ansi.js";
+
+let stderrLines: string[] = [];
+
+function captured(): string {
+  return stderrLines.map(stripAnsi).join("");
+}
+
+beforeEach(() => {
+  resetUiContextForTest();
+  initUiContext({ isTTY: false }); // non-TTY for deterministic output
+  stderrLines = [];
+  spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderrLines.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  resetUiContextForTest();
+});
+
+describe("Spinner — non-TTY mode", () => {
+  test("start() prints label followed by ...", () => {
+    new Spinner("Loading").start();
+    expect(captured()).toContain("Loading...");
+  });
+
+  test("succeed() prints ✓ and label", () => {
+    const s = new Spinner("Work");
+    s.start();
+    stderrLines = [];
+    s.succeed("all done");
+    expect(captured()).toContain("✓");
+    expect(captured()).toContain("all done");
+  });
+
+  test("succeed() falls back to constructor label if none given", () => {
+    const s = new Spinner("My task");
+    s.start();
+    stderrLines = [];
+    s.succeed();
+    expect(captured()).toContain("My task");
+  });
+
+  test("fail() prints ✗ and label", () => {
+    const s = new Spinner("Work");
+    s.start();
+    stderrLines = [];
+    s.fail("went wrong");
+    expect(captured()).toContain("✗");
+    expect(captured()).toContain("went wrong");
+  });
+
+  test("update() changes label used by succeed", () => {
+    const s = new Spinner("old");
+    s.start();
+    s.update("new label");
+    stderrLines = [];
+    s.succeed();
+    expect(captured()).toContain("new label");
+  });
+});
+
+describe("Spinner — quiet mode", () => {
+  test("start() is a no-op when quiet=true", () => {
+    initUiContext({ quiet: true });
+    new Spinner("Task").start();
+    expect(stderrLines).toHaveLength(0);
+  });
+
+  test("succeed() is a no-op when quiet=true", () => {
+    initUiContext({ quiet: true });
+    const s = new Spinner("Task");
+    s.start();
+    s.succeed("done");
+    expect(stderrLines).toHaveLength(0);
+  });
+
+  test("fail() is a no-op when quiet=true", () => {
+    initUiContext({ quiet: true });
+    const s = new Spinner("Task");
+    s.start();
+    s.fail("nope");
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+describe("Spinner — dryRun mode", () => {
+  test("start() is a no-op when dryRun=true", () => {
+    initUiContext({ dryRun: true });
+    new Spinner("Task").start();
+    expect(stderrLines).toHaveLength(0);
+  });
+});

--- a/tests/unit/ui-table.test.ts
+++ b/tests/unit/ui-table.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { initUiContext, resetUiContextForTest } from "../../src/ui/context.js";
+import { renderTable } from "../../src/ui/table.js";
+import { stripAnsi } from "../../src/ui/ansi.js";
+
+beforeEach(() => {
+  resetUiContextForTest();
+  initUiContext({ isTTY: false }); // no ANSI codes
+});
+
+afterEach(() => {
+  resetUiContextForTest();
+});
+
+function lines(output: string): string[] {
+  return output.split("\n").filter((l) => l.trim() !== "");
+}
+
+describe("renderTable", () => {
+  test("includes all header labels", () => {
+    const out = stripAnsi(renderTable(["NAME", "VERSION"], [["react-ts", "1.0.0"]]));
+    expect(out).toContain("NAME");
+    expect(out).toContain("VERSION");
+  });
+
+  test("includes separator row of ─ characters", () => {
+    const out = stripAnsi(renderTable(["NAME", "VERSION"], [["react-ts", "1.0.0"]]));
+    expect(out).toContain("─");
+  });
+
+  test("includes all data rows", () => {
+    const out = stripAnsi(renderTable(["A", "B"], [["row1a", "row1b"], ["row2a", "row2b"]]));
+    expect(out).toContain("row1a");
+    expect(out).toContain("row2b");
+  });
+
+  test("right-aligns numeric columns", () => {
+    const out = stripAnsi(renderTable(
+      ["NAME", "DISK"],
+      [["short", "3.5 GB"], ["much-longer-name", "12 GB"]],
+      { align: ["left", "right"] },
+    ));
+    // DISK column values should be right-padded to same width — check they appear
+    expect(out).toContain("3.5 GB");
+    expect(out).toContain("12 GB");
+  });
+
+  test("column widths respect header width when data is shorter", () => {
+    const out = stripAnsi(renderTable(
+      ["VERY_LONG_HEADER", "B"],
+      [["x", "y"]],
+    ));
+    // header and data should both be on present
+    const ls = lines(out);
+    expect(ls[0]).toContain("VERY_LONG_HEADER");
+    expect(ls[2]).toContain("x");
+  });
+
+  test("explicit widths override computed widths", () => {
+    const out = stripAnsi(renderTable(
+      ["A"],
+      [["hi"]],
+      { widths: [20] },
+    ));
+    // "A" should be padded to 20 chars
+    const header = lines(out)[0];
+    expect(header).toContain("A" + " ".repeat(19));
+  });
+
+  test("handles empty rows", () => {
+    const out = stripAnsi(renderTable(["COL"], []));
+    expect(out).toContain("COL");
+    expect(out).toContain("─");
+  });
+});


### PR DESCRIPTION
…utput (#18)

Add src/ui/ — a zero-dependency ANSI terminal framework:
- ansi.ts: ANSI escape constants, colorize helpers, sparkline (▁▂▃▄▅▆▇█)
- context.ts: UiContext singleton (quiet/isTTY/dryRun), --quiet global flag
- print.ts: ui.info/warn/error/success/dim/divider/scoreDelta with colour prefixes
- spinner.ts: Braille-frame animated Spinner; degrades to plain text in non-TTY
- mascot.ts: 'Spark' — 6-frame dancing ASCII robot MascotSpinner (TTY only)
- progress.ts: ByteProgress (download speed + ETA) + StepProgress (N/M bar)
- table.ts: renderTable with bold headers, separator, left/right alignment

Integrations:
- generate: MascotSpinner during TTFT gap (--stream); Spinner for buffered mode
- chat: MascotSpinner while waiting for first token between turns
- models/pull: ByteProgress with MB/s + ETA replaces bare carriage-return writes
- training/runner: sparkline appended to each loss line (e.g. Iter   50  loss 0.3421  ▄▃▂▁)
- adaptor eval: StepProgress for N/M prompt loop via onProgress callback
- adaptor self-improve: round banners (╌╌╌ Round 2/3 ╌╌╌) + coloured score deltas
- adaptor list/models list: renderTable replaces manual padEnd
- data/adaptor commands: ui.success/warn/error replaces raw process.stderr.write

62 new tests; no regressions on existing 214 unit tests.

https://claude.ai/code/session_014paTkuQtUrPFNKzuBAPFbP